### PR TITLE
Refactor email verification sanitising names

### DIFF
--- a/app/actions/registerUser.js
+++ b/app/actions/registerUser.js
@@ -3,7 +3,7 @@
 import User from '@/models/User';
 import connectDB from '@/config/database';
 import {
-	normalizeEmail,
+	sanitiseEmail,
 	sendVerificationEmail,
 } from '@/utils/emailVerification';
 import {
@@ -28,14 +28,14 @@ export default async function registerUser(formData) {
 
 		const trimmedFirstName = firstName?.trim();
 		const trimmedLastName = lastName?.trim();
-		const sanitizedEmail = normalizeEmail(email);
+		const sanitisedEmail = sanitiseEmail(email);
 
 		if (!trimmedFirstName || !trimmedLastName) {
 			throw new Error('First name and last name are required.');
 		}
 
 		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-		if (!emailRegex.test(sanitizedEmail)) {
+		if (!emailRegex.test(sanitisedEmail)) {
 			throw new Error('Invalid email format.');
 		}
 
@@ -49,7 +49,7 @@ export default async function registerUser(formData) {
 		const formattedFirstName = formatName(trimmedFirstName);
 		const formattedLastName = formatName(trimmedLastName);
 
-		const existingUser = await User.findOne({ email: sanitizedEmail });
+		const existingUser = await User.findOne({ email: sanitisedEmail });
 		if (existingUser) {
 			return {
 				success: false,
@@ -61,7 +61,7 @@ export default async function registerUser(formData) {
 		const newUser = new User({
 			firstName: formattedFirstName,
 			lastName: formattedLastName,
-			email: sanitizedEmail,
+			email: sanitisedEmail,
 			emailVerified: null,
 			password,
 		});
@@ -74,7 +74,7 @@ export default async function registerUser(formData) {
 			await sendVerificationEmail({
 				userId: newUser._id,
 				firstName: formattedFirstName,
-				email: sanitizedEmail,
+				email: sanitisedEmail,
 			});
 		} catch (emailError) {
 			emailSent = false;
@@ -83,7 +83,7 @@ export default async function registerUser(formData) {
 
 		return {
 			success: true,
-			email: sanitizedEmail,
+			email: sanitisedEmail,
 			emailSent,
 			requiresEmailVerification: true,
 		};

--- a/app/actions/resendVerificationEmail.ts
+++ b/app/actions/resendVerificationEmail.ts
@@ -3,7 +3,7 @@
 
 import connectDB from '@/config/database';
 import User from '@/models/User';
-import { normalizeEmail, sendVerificationEmail } from '@/utils/emailVerification';
+import { sanitiseEmail, sendVerificationEmail } from '@/utils/emailVerification';
 import { enforceRateLimit, getRequestIp } from '@/utils/rateLimit';
 
 type ResendVerificationResult = {
@@ -17,7 +17,7 @@ export async function resendVerificationEmail(
 
 	await connectDB();
 
-	const email = normalizeEmail(emailRaw);
+	const email = sanitiseEmail(emailRaw);
 
 	// Always return ok (prevents account enumeration)
 	if (!email || !email.includes('@')) return { ok: true };

--- a/app/actions/updateProfileDetails.ts
+++ b/app/actions/updateProfileDetails.ts
@@ -23,8 +23,8 @@ export type UpdateProfileDetailsResult = {
   requiresEmailVerification: boolean;
 };
 
-const normalizeEmail = (value: unknown): string =>
-  (value ?? '').toString().trim().toLowerCase();
+const sanitiseEmail = (value: unknown): string =>
+  typeof value === 'string' ? value.trim().toLowerCase() : '';
 
 const normalizeName = (value: unknown): string => (value ?? '').toString().trim();
 
@@ -48,7 +48,7 @@ export default async function updateProfileDetails(
   }
 
   // Normalise inputs
-  const nextEmail = normalizeEmail(email);
+  const nextEmail = sanitiseEmail(email);
   const nextFirstName = normalizeName(firstName);
   const nextLastName = normalizeName(lastName);
 
@@ -64,7 +64,7 @@ export default async function updateProfileDetails(
     throw new Error('Please enter your first and last name.');
   }
 
-  const currentEmail = normalizeEmail(user.email);
+  const currentEmail = sanitiseEmail(user.email);
   const emailChanged = nextEmail !== currentEmail;
 
   // Prevent duplicates if user is changing email

--- a/app/recipes/verify/check-email/page.tsx
+++ b/app/recipes/verify/check-email/page.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Stack, Typography } from '@mui/material';
 import Link from 'next/link';
 
 import ResendVerificationForm from '@/components/ResendVerificationForm';
-import { normalizeEmail } from '@/utils/emailVerification';
+import { sanitiseEmail } from '@/utils/emailVerification';
 
 type CheckEmailPageProps = Readonly<{
 	searchParams?: Readonly<{
@@ -15,7 +15,7 @@ export default function CheckEmailPage({ searchParams }: CheckEmailPageProps) {
 	const emailParam = searchParams?.email;
 	const sentParam = searchParams?.sent;
 
-	const email = normalizeEmail(
+	const email = sanitiseEmail(
 		Array.isArray(emailParam) ? emailParam[0] : emailParam,
 	);
 	const emailSent =

--- a/app/recipes/verify/invalid/page.tsx
+++ b/app/recipes/verify/invalid/page.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Stack, Typography } from '@mui/material';
 import Link from 'next/link';
 import ResendVerificationForm from '@/components/ResendVerificationForm';
-import { normalizeEmail } from '@/utils/emailVerification';
+import { sanitiseEmail } from '@/utils/emailVerification';
 
 type VerifyInvalidPageProps = {
 	searchParams: Promise<{ email?: string | string[] }>;
@@ -12,7 +12,7 @@ export default async function VerifyInvalidPage({
 }: VerifyInvalidPageProps) {
 	const sp = await searchParams;
 	const emailParam = sp?.email;
-	const email = normalizeEmail(Array.isArray(emailParam) ? emailParam[0] : emailParam);
+	const email = sanitiseEmail(Array.isArray(emailParam) ? emailParam[0] : emailParam);
 
 	return (
 		<Box data-testid='verify-invalid' sx={{ mt: 10, textAlign: 'center' }}>

--- a/app/recipes/verify/page.tsx
+++ b/app/recipes/verify/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import { redirect } from 'next/navigation';
 import connectDB from '@/config/database';
-import { normalizeEmail, verifyEmailToken } from '@/utils/emailVerification';
+import { sanitiseEmail, verifyEmailToken } from '@/utils/emailVerification';
 
 type VerifyPageProps = {
 	searchParams: Promise<{
@@ -15,7 +15,7 @@ export default async function VerifyPage({ searchParams }: VerifyPageProps) {
 	const sp = await searchParams;
 	const emailParam = sp?.email;
 	const tokenParam = sp?.token;
-	const email = normalizeEmail(Array.isArray(emailParam) ? emailParam[0] : emailParam);
+	const email = sanitiseEmail(Array.isArray(emailParam) ? emailParam[0] : emailParam);
 	const token = Array.isArray(tokenParam) ? tokenParam[0] : tokenParam;
 
 	const invalidRedirect = email

--- a/utils/emailVerification.ts
+++ b/utils/emailVerification.ts
@@ -1,5 +1,5 @@
-import crypto from 'node:crypto';
 import type { Types } from 'mongoose';
+import crypto from 'node:crypto';
 
 import EmailVerificationToken from '@/models/EmailVerificationToken';
 import User from '@/models/User';
@@ -23,7 +23,21 @@ type VerifyEmailTokenResult = {
 };
 
 export function normalizeEmail(value: unknown): string {
-	return (value ?? '').toString().trim().toLowerCase();
+	if (value == null) return '';
+
+	const t = typeof value;
+	if (t === 'string' || t === 'number' || t === 'boolean') {
+		return String(value).trim().toLowerCase();
+	}
+
+	// If value is an object with a custom toString (e.g. ObjectId), use that
+	// instead of Object.prototype.toString which yields '[object Object]'.
+	if (value && typeof (value as any).toString === 'function' && (value as any).toString !== Object.prototype.toString) {
+		return String((value as any).toString()).trim().toLowerCase();
+	}
+
+	// For symbols, functions, plain objects, etc., return empty string.
+	return '';
 }
 
 export function hashVerificationToken(token: string): string {

--- a/utils/emailVerification.ts
+++ b/utils/emailVerification.ts
@@ -22,22 +22,10 @@ type VerifyEmailTokenResult = {
 	status: 'verified' | 'already_verified' | 'invalid';
 };
 
-export function normalizeEmail(value: unknown): string {
-	if (value == null) return '';
-
-	const t = typeof value;
-	if (t === 'string' || t === 'number' || t === 'boolean') {
-		return String(value).trim().toLowerCase();
-	}
-
-	// If value is an object with a custom toString (e.g. ObjectId), use that
-	// instead of Object.prototype.toString which yields '[object Object]'.
-	if (value && typeof (value as any).toString === 'function' && (value as any).toString !== Object.prototype.toString) {
-		return String((value as any).toString()).trim().toLowerCase();
-	}
-
-	// For symbols, functions, plain objects, etc., return empty string.
-	return '';
+// Only trims/lowercases for the verification-email flow. Future canonical
+// duplicate-account lookup should use a separate sanitiseEmailForLookup helper.
+export function sanitiseEmail(value: unknown): string {
+	return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
 export function hashVerificationToken(token: string): string {
@@ -145,11 +133,11 @@ function getRecipesAppUrl(): string {
 }
 
 export function buildVerificationUrl(email: string, token: string): string {
-	const normalizedEmail = normalizeEmail(email);
+	const sanitisedEmail = sanitiseEmail(email);
 	const recipesAppUrl = getRecipesAppUrl();
 
 	return `${recipesAppUrl}/verify?email=${encodeURIComponent(
-		normalizedEmail,
+		sanitisedEmail,
 	)}&token=${encodeURIComponent(token)}`;
 }
 
@@ -157,18 +145,18 @@ export async function createEmailVerificationToken({
 	userId,
 	email,
 }: Pick<VerificationEmailInput, 'userId' | 'email'>) {
-	const normalizedEmail = normalizeEmail(email);
+	const sanitisedEmail = sanitiseEmail(email);
 	const rawToken = crypto.randomBytes(32).toString('hex');
 	const tokenHash = hashVerificationToken(rawToken);
 	const expiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TTL_MS);
 
 	await EmailVerificationToken.deleteMany({
-		$or: [{ user: userId }, { email: normalizedEmail }],
+		$or: [{ user: userId }, { email: sanitisedEmail }],
 	});
 
 	await EmailVerificationToken.create({
 		user: userId,
-		email: normalizedEmail,
+		email: sanitisedEmail,
 		tokenHash,
 		expiresAt,
 	});
@@ -184,21 +172,21 @@ export async function sendVerificationEmail({
 	firstName,
 	email,
 }: VerificationEmailInput) {
-	const normalizedEmail = normalizeEmail(email);
+	const sanitisedEmail = sanitiseEmail(email);
 	const { token, expiresAt } = await createEmailVerificationToken({
 		userId,
-		email: normalizedEmail,
+		email: sanitisedEmail,
 	});
 
-	const verificationUrl = buildVerificationUrl(normalizedEmail, token);
+	const verificationUrl = buildVerificationUrl(sanitisedEmail, token);
 	const emailContent = buildVerificationEmail({
 		firstName: firstName?.trim() || 'there',
-		email: normalizedEmail,
+		email: sanitisedEmail,
 		verificationUrl,
 	});
 
 	await sendMail({
-		to: normalizedEmail,
+		to: sanitisedEmail,
 		subject: emailContent.subject,
 		text: emailContent.text,
 		html: emailContent.html,
@@ -214,15 +202,15 @@ export async function verifyEmailToken({
 	email,
 	token,
 }: VerifyEmailTokenInput): Promise<VerifyEmailTokenResult> {
-	const normalizedEmail = normalizeEmail(email);
+	const sanitisedEmail = sanitiseEmail(email);
 	const rawToken = token.trim();
 	const now = new Date();
 
-	if (!normalizedEmail || !rawToken) {
+	if (!sanitisedEmail || !rawToken) {
 		return { status: 'invalid' };
 	}
 
-	const user = await User.findOne({ email: normalizedEmail });
+	const user = await User.findOne({ email: sanitisedEmail });
 	if (!user) {
 		return { status: 'invalid' };
 	}
@@ -236,7 +224,7 @@ export async function verifyEmailToken({
 
 	const verificationToken = await EmailVerificationToken.findOne({
 		user: user._id,
-		email: normalizedEmail,
+		email: sanitisedEmail,
 		tokenHash,
 		expiresAt: { $gt: now },
 	});

--- a/utils/getSessionUser.ts
+++ b/utils/getSessionUser.ts
@@ -20,15 +20,15 @@ export const getSessionUser = async (): Promise<SessionUser | null> => {
 
 		await connectDB();
 
-		const normalizedEmail = email.toLowerCase().trim();
-		const userDoc = await User.findOne({ email: normalizedEmail })
+		const sanitisedEmail = email.toLowerCase().trim();
+		const userDoc = await User.findOne({ email: sanitisedEmail })
 			.select('_id firstName lastName email image')
 			.lean();
 
 		if (!userDoc) return null;
 
 		return {
-			id: userDoc._id.toString(),
+			id: userDoc._id.toHexString(),
 			name: session.user?.name ?? `${userDoc.firstName} ${userDoc.lastName}`,
 			email: userDoc.email,
 			image: session.user?.image ?? userDoc.image ?? null,


### PR DESCRIPTION
## Summary

Refactors email verification naming to make the intent clearer.

- Renamed normalizeEmail to sanitiseEmail
- Updated related local variable names from normalizedEmail / sanitizedEmail to sanitisedEmail
- Kept behaviour limited to trimming and lowercasing email strings
- Added/kept clarification that future canonical duplicate-account lookup should use a separate helper

## Notes

This PR does not add Gmail canonicalisation, a normalisedEmail user field, database indexes, migrations, or duplicate-account lookup changes. Those will be handled separately as part of the next Phase 2 work.

## Verification

- pnpm exec tsc --noEmit
- pnpm run build
- git diff --check